### PR TITLE
Fix compatibility with AsyncDisplayKit

### DIFF
--- a/Source/SFFocusViewLayout.swift
+++ b/Source/SFFocusViewLayout.swift
@@ -126,6 +126,10 @@ public class SFFocusViewLayout: UICollectionViewLayout {
 private extension UICollectionViewLayout {
 
     var numberOfItems: Int {
+        guard collectionView?.numberOfSections() > 0 else {
+            return 0
+        }
+        
         return collectionView!.numberOfItemsInSection(0)
     }
 

--- a/Tests/CollectionViewController.swift
+++ b/Tests/CollectionViewController.swift
@@ -13,6 +13,8 @@ private let reuseIdentifier = "Cell"
 class CollectionViewController: UICollectionViewController {
 
     var items = [Int]()
+    
+    var numberOfSectionsToReturn = 1
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,7 +25,7 @@ class CollectionViewController: UICollectionViewController {
     // MARK: UICollectionViewDataSource
 
     override func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {
-        return 1
+        return numberOfSectionsToReturn
     }
 
 

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -81,5 +81,10 @@ class Tests: XCTestCase {
     func testLayoutShouldInvalidateLayoutForBoundsChange() {
         XCTAssertTrue(focusViewLayout.shouldInvalidateLayoutForBoundsChange(CGRect()))
     }
+    
+    func testCanPrepareLayoutForCollectionViewWithZeroSections() {
+        collectionViewController?.numberOfSectionsToReturn = 0
+        focusViewLayout.prepareLayout()
+    }
 
 }


### PR DESCRIPTION
This fixes an NSInternalInconsistencyExceptionn that occurs when using SFFocusViewLayout with AsyncDisplayKit. The commit message has more details.
